### PR TITLE
v0.1.4: removed toy_models dep from IZ mod

### DIFF
--- a/examples/sw21_tutorial.ipynb
+++ b/examples/sw21_tutorial.ipynb
@@ -20,17 +20,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting sim-tools==v0.1.3\n",
+      "  Downloading sim_tools-0.1.3-py3-none-any.whl (14 kB)\n",
+      "Requirement already satisfied: scipy>=1.4.1 in /home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages (from sim-tools==v0.1.3) (1.4.1)\n",
+      "Requirement already satisfied: matplotlib>=3.1.3 in /home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages (from sim-tools==v0.1.3) (3.1.3)\n",
+      "Requirement already satisfied: pandas>=1.0.1 in /home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages (from sim-tools==v0.1.3) (1.0.1)\n",
+      "Requirement already satisfied: seaborn>=0.10.0 in /home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages (from sim-tools==v0.1.3) (0.10.0)\n",
+      "Requirement already satisfied: numpy>=1.18.1 in /home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages (from sim-tools==v0.1.3) (1.18.1)\n",
+      "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages (from matplotlib>=3.1.3->sim-tools==v0.1.3) (2.4.7)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in /home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages (from matplotlib>=3.1.3->sim-tools==v0.1.3) (1.3.1)\n",
+      "Requirement already satisfied: python-dateutil>=2.1 in /home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages (from matplotlib>=3.1.3->sim-tools==v0.1.3) (2.8.1)\n",
+      "Requirement already satisfied: cycler>=0.10 in /home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages (from matplotlib>=3.1.3->sim-tools==v0.1.3) (0.10.0)\n",
+      "Requirement already satisfied: pytz>=2017.2 in /home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages (from pandas>=1.0.1->sim-tools==v0.1.3) (2021.1)\n",
+      "Requirement already satisfied: six>=1.5 in /home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages (from python-dateutil>=2.1->matplotlib>=3.1.3->sim-tools==v0.1.3) (1.15.0)\n",
+      "Installing collected packages: sim-tools\n",
+      "  Attempting uninstall: sim-tools\n",
+      "    Found existing installation: sim-tools 0.1.0\n",
+      "    Uninstalling sim-tools-0.1.0:\n",
+      "      Successfully uninstalled sim-tools-0.1.0\n",
+      "Successfully installed sim-tools-0.1.3\n"
+     ]
+    }
+   ],
    "source": [
     "#run this first to install the OvS procedures so we can use them in the tutorial.\n",
-    "!pip install sim-tools"
+    "!pip install sim-tools==v0.1.3"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,13 +65,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sim_tools.ovs.toy_models import (custom_guassian_model,\n",
-    "                                      guassian_sequence_model,\n",
-    "                                      random_guassian_model,\n",
+    "from sim_tools.ovs.toy_models import (custom_gaussian_model,\n",
+    "                                      gaussian_sequence_model,\n",
+    "                                      random_gaussian_model,\n",
     "                                      ManualOptimiser)"
    ]
   },
@@ -144,11 +170,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "manual_opt = ManualOptimiser(model=guassian_sequence_model(1, 10),\n",
+    "manual_opt = ManualOptimiser(model=gaussian_sequence_model(1, 10),\n",
     "                             n_designs=10)"
    ]
   },
@@ -161,9 +187,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ManualOptimiser(model=BanditCasino(), n_designs=10, verbose=False)\n"
+     ]
+    }
+   ],
    "source": [
     "print(manual_opt)"
    ]
@@ -177,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,18 +229,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([3, 3, 3, 3, 3, 3, 3, 3, 3, 3], dtype=int32)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "manual_opt.allocations"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1.2, 1.3, 2.8, 4. , 4.6, 5.8, 7.4, 7.9, 9.4, 9.4])"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "np.set_printoptions(precision=1) # this is a hack to view at 1 decimal place.\n",
     "manual_opt.means"
@@ -214,9 +270,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.3, 3.5, 1.6, 0.2, 0.8, 0.2, 0.8, 0.3, 0.5, 0.1])"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "manual_opt.vars"
    ]
@@ -231,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,27 +307,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([3, 3, 3, 3, 3, 3, 3, 4, 4, 4], dtype=int32)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "manual_opt.allocations"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1.2, 1.3, 2.8, 4. , 4.6, 5.8, 7.4, 7.9, 9.5, 9.8])"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "manual_opt.means"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.3, 3.5, 1.6, 0.2, 0.8, 0.2, 0.8, 0.2, 0.4, 0.8])"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "manual_opt.vars"
    ]
@@ -281,12 +381,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
     "#create random problem\n",
-    "rnd_model = random_guassian_model(mean_low=5, mean_high=25, \n",
+    "rnd_model = random_gaussian_model(mean_low=5, mean_high=25, \n",
     "                                  var_low=0.5, var_high=2.5,\n",
     "                                  n_designs=10)\n",
     "\n",
@@ -333,9 +433,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "cannot import name 'guassian_bandit_sequence' from 'sim_tools.ovs.toy_models' (/home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages/sim_tools/ovs/toy_models.py)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-18-91075280194b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0msim_tools\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0movs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mindifference_zone\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mKN\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mKNPlusPlus\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages/sim_tools/ovs/indifference_zone.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     12\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mnumpy\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 14\u001b[0;31m from .toy_models import (BanditCasino,    \n\u001b[0m\u001b[1;32m     15\u001b[0m                          \u001b[0mGaussianBandit\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m                          \u001b[0mguassian_bandit_sequence\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mImportError\u001b[0m: cannot import name 'guassian_bandit_sequence' from 'sim_tools.ovs.toy_models' (/home/tom/anaconda3/envs/sim_tools_dev/lib/python3.8/site-packages/sim_tools/ovs/toy_models.py)"
+     ]
+    }
+   ],
    "source": [
     "from sim_tools.ovs.indifference_zone import KN, KNPlusPlus"
    ]
@@ -355,9 +468,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'KN' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-17-41e70f4243cb>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[0;31m#then we create the KN R&S object and pass in our parameters.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[0;31m#note that this doesn't run the optimisation yet.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 11\u001b[0;31m kn = KN(model=model, \n\u001b[0m\u001b[1;32m     12\u001b[0m         \u001b[0mn_designs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mN_DESIGNS\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     13\u001b[0m         \u001b[0mdelta\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mDELTA\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'KN' is not defined"
+     ]
+    }
+   ],
    "source": [
     "N_DESIGNS = 10\n",
     "DELTA = 1.0\n",
@@ -365,7 +490,7 @@
     "N_0 = 5\n",
     "\n",
     "#first we create the simulation model. \n",
-    "model = guassian_sequence_model(1, N_DESIGNS)\n",
+    "model = gaussian_sequence_model(1, N_DESIGNS)\n",
     "\n",
     "#then we create the KN R&S object and pass in our parameters.\n",
     "#note that this doesn't run the optimisation yet.\n",

--- a/sim_tools/__init__.py
+++ b/sim_tools/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 __author__ = 'Thomas Monks'

--- a/sim_tools/ovs/indifference_zone.py
+++ b/sim_tools/ovs/indifference_zone.py
@@ -11,10 +11,10 @@ update the variance estimate of designs at each stage.
 
 import numpy as np
 
-from .toy_models import (BanditCasino,    
-                         GaussianBandit, 
-                         guassian_bandit_sequence, 
-                         guassian_sequence_model)
+# from .toy_models import (BanditCasino,    
+#                          GaussianBandit, 
+#                          gaussian_bandit_sequence, 
+#                          gaussian_sequence_model)
 
 class KNPlusPlus(object):
     '''


### PR DESCRIPTION
v0.1.4 fixed probloem with `ovs.indifference_zone`.  This had unnecessary dependency on `ovs_toy_models.` guassian model routines.  These have been removed as they broke after fix in v0.1.3.  