### PR TITLE
Patch v0.7.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Consistent identifier (represents all versions, resolves to latest): [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4553641.svg)](https://doi.org/10.5281/zenodo.4553641)
 
 
-## v0.7.0  
+## v0.7.1 
+
+### Fixed
+
+* Patched `ReplicationsAlgorithm` look ahead will now correctly use `_klimit()` to calculate extra no. replications to run.
+
+## [v0.7.0](https://github.com/TomMonks/sim-tools/releases/tag/v0.7.0) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14834956.svg)](https://doi.org/10.5281/zenodo.14834956)
 
 ### Added
 

--- a/sim_tools/__init__.py
+++ b/sim_tools/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 __author__ = 'Thomas Monks'
 
 from . import datasets, distributions, time_dependent, ovs, output_analysis

--- a/sim_tools/output_analysis.py
+++ b/sim_tools/output_analysis.py
@@ -571,7 +571,7 @@ class ReplicationsAlgorithm:
                     k = 1
 
                     # look ahead loop
-                    while converged and k <= self.look_ahead:
+                    while converged and k <= self._klimit():
                         if self.verbose:
                             print(f"{self.n+k}", end=", ")
 


### PR DESCRIPTION
## Fixed

* Patched `ReplicationsAlgorithm` look ahead will now correctly use `_klimit()` to calculate extra no. replications to run.