### PR TITLE
docs(changes): v0.10.0 + zen badge v.0.9.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 Consistent identifier (represents all versions, resolves to latest): [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4553641.svg)](https://doi.org/10.5281/zenodo.4553641)
 
-## Unreleased
+## [v0.10.0](https://github.com/TomMonks/sim-tools/releases/tag/v0.10.0)[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.16754108.svg)](https://doi.org/10.5281/zenodo.16754108)
 
 ### Added
 
@@ -18,7 +18,7 @@ Consistent identifier (represents all versions, resolves to latest): [![DOI](htt
 
 * Some linting of `_validation.py`, `time_dependent.py`, `distributions.py` and `trace.py`.
 
-## v0.9.1
+## [v0.9.1](https://github.com/TomMonks/sim-tools/releases/tag/v0.9.1)[[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.16754108.svg)](https://doi.org/10.5281/zenodo.16754108)]
 
 ### Added
 


### PR DESCRIPTION
* Added release details to `CHANGES`
* Added missing markdown badge for Zenodo DOI to v0.9.1 in `CHANGES`