### PR TITLE
fix(DistributionRegistry): reenable IDE hints by adjusting typing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 Consistent identifier (represents all versions, resolves to latest): [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4553641.svg)](https://doi.org/10.5281/zenodo.4553641)
 
+## v1.0.1
+
+### Fixed
+
+* **Type Hinting and Pylance Support**: Adjusted type hinting within `@register` decorator to enable display of docstrings, hover hints and argument suggestions.
+
 ## v1.0.0
 
 v1.0.0 centres on **multi-metric support** - `confidence_interval_method` and `ReplicationsAlgorithm` can now analyse multiple metrics at once, driving changes to syntax (explicit `metrics` argument), adapter formats, defaults, docs, plotting, and tests to support the new capability.
@@ -65,14 +71,14 @@ v1.0.0 centres on **multi-metric support** - `confidence_interval_method` and `R
 
 ### Added
 
-* `distributions.DistributionRegistry` - for batch creation of standard distributions from a dictionary or list.  
+* `distributions.DistributionRegistry` - for batch creation of standard distributions from a dictionary or list.
 * DOCS: `DistributionRegistry` explaination and examples including use of JSON to store configs.
 * `distributions.spawn_seeds` function to support creation of PRNG streams.
 * `Hyperexponential` - A continuous probability distribution that is a mixture (weighted sum) of
     exponential distributions. It has a higher coefficient of variation than
     a single exponential distribution, making it useful for modeling highly
     variable processes or heavy-tailed phenomena.
-* `RawContinuousEmpirical` - A distribution that performs linear interpolation between data points according to 
+* `RawContinuousEmpirical` - A distribution that performs linear interpolation between data points according to
     the algorithm described in Law & Kelton's "Simulation Modeling and Analysis".
 * `sim_tools._validation`: internal module that contains common validation routines for `sim_tools` functions and classes.
 * All distribution classes updated to include valudation of input parameters.
@@ -80,7 +86,7 @@ v1.0.0 centres on **multi-metric support** - `confidence_interval_method` and `R
 
 ### Changed
 
-* `Distribution` changed from abstract base class to `Protocol`.  All inheritance removed from concrete classes. 
+* `Distribution` changed from abstract base class to `Protocol`.  All inheritance removed from concrete classes.
 * Added `__repr__()` to all distribution classes.
 * DOCS: improved docstrings for all distribution classes
 * BREAKING: `Discrete` -> `DiscreteEmpirical`
@@ -134,8 +140,8 @@ v1.0.0 centres on **multi-metric support** - `confidence_interval_method` and `R
 * `ReplicationsAlgorithmModelAdapter` - a `Protocol` to adapt any model to work with with `ReplicationsAlgorithm`
 * `confidence_interval_method` - select the number of replication using the classical confidence interval method
 * `plotly_confidence_interval_method` - visualise the confidence interval method using plotly.
-* `ReplicationObserver` a `Protocol` for observering the replications algorithm 
-*  `ReplicationTabulizer` record replications algorithm in a pandas dataframe. 
+* `ReplicationObserver` a `Protocol` for observering the replications algorithm
+*  `ReplicationTabulizer` record replications algorithm in a pandas dataframe.
 * Documentation for `ReplicationsAlgorithm`
 
 ### Updated
@@ -146,7 +152,7 @@ v1.0.0 centres on **multi-metric support** - `confidence_interval_method` and `R
 
 ### Fixed
 
-* BUILD: added rich library. 
+* BUILD: added rich library.
 
 ### Removed
 
@@ -194,7 +200,7 @@ v1.0.0 centres on **multi-metric support** - `confidence_interval_method` and `R
 
 ## [v0.3.2](https://github.com/TomMonks/sim-tools/releases/tag/v0.3.2) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10625581.svg)](https://doi.org/10.5281/zenodo.10625581)
 
-### Changed 
+### Changed
 
 * Update Github action to publish to pypi. Use setuptools instead of build
 
@@ -239,7 +245,7 @@ v1.0.0 centres on **multi-metric support** - `confidence_interval_method` and `R
 
 ### Added
 
-* Added `sim_tools.distribution` module.  This contains classes representing popular sampling distributions for Discrete-event simulation. All classes encapsulate a `numpy.random.Generator` object, a random seed, and the parameters of a sampling distribution.  
+* Added `sim_tools.distribution` module.  This contains classes representing popular sampling distributions for Discrete-event simulation. All classes encapsulate a `numpy.random.Generator` object, a random seed, and the parameters of a sampling distribution.
 
 ### Changed
 

--- a/sim_tools/__init__.py
+++ b/sim_tools/__init__.py
@@ -1,4 +1,5 @@
 """sim-tools"""
-__version__ = '1.0.0'
+
+__version__ = "1.0.1"
 
 from . import datasets, distributions, time_dependent, ovs, output_analysis

--- a/sim_tools/distributions.py
+++ b/sim_tools/distributions.py
@@ -99,6 +99,7 @@ from typing import (
     List,
     Dict,
     runtime_checkable,
+    TypeVar,
 )
 
 import numpy as np
@@ -120,6 +121,8 @@ from sim_tools._validation import (
     is_probability_vector,
     is_positive_array,
 )
+
+T = TypeVar("T", bound=type)
 
 
 # pylint: disable=too-few-public-methods
@@ -297,7 +300,7 @@ class DistributionRegistry:
             Decorator function that registers the class
         """
 
-        def decorator(distribution_class: Distribution):
+        def decorator(distribution_class: T) -> T:
             nonlocal name
             if name is None:
                 name = distribution_class.__name__


### PR DESCRIPTION
This pull request contains a small change to how types are handled in the `register` decorator.

This is to correct an issue I observed while using the package in a model; the docstring and hints were not appearing within VSCode when hovering over the class. 

v1.0.0 behaviour:

<img width="512" height="179" alt="image" src="https://github.com/user-attachments/assets/64ca7d63-6e2d-4c2f-9258-25089a2b7efb" />

After v1.0.1 changes (this PR): 

<img width="887" height="357" alt="image" src="https://github.com/user-attachments/assets/28543407-6d87-45f4-8644-0a8ea5a3cca1" />

I don't think this is just a local issue with how my VSCode is set up - it occurs in a fresh codespace too: 

<img width="518" height="210" alt="image" src="https://github.com/user-attachments/assets/3b633f3c-a941-4af0-9d40-25f4c3e43abf" />

<img width="775" height="398" alt="image" src="https://github.com/user-attachments/assets/4f2158d1-824a-4ac0-bac8-6dbb454ba3ee" />

After making the changes, I have confirmed all tests are passing. 14 warnings occur, but all are relating to deprecated functions unrelated to the area changed. 

Docs have rebuilt successfully but no changes were actually made to the output files; however, this gives me further confidence that the change hasn't caused any downstream issues as the DistributionRegistry page has built correctly.

Worth noting that this isn't an area of Python I'm particular familiar with, so there may well be a better way of solving the issue! 

Also worth noting I forked from master rather than dev before spotting that in the contributing guidelines. However, dev currently seems to be out of date, so I think this may be better. 

I've not added myself to the author list as it is a very minor contribution! 
